### PR TITLE
Remove duplicate root redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,3 @@
-/ / 301
 /zumba-dance-classes/ /zumba-classes/ 301
 /zumba-for-seniors/ /zumba-for-seniors/ 301
 /top-10-fun-activities-for-fitness-in-murwillumbah/ /blog/fitness-activities-murwillumbah/ 301

--- a/test_redirects.sh
+++ b/test_redirects.sh
@@ -3,7 +3,6 @@ set -e
 base="https://kazumbah.com.au"
 
 declare -A map=(
-  ["/"]="/"
   ["/zumba-dance-classes/"]="/zumba-classes/"
   ["/zumba-for-seniors/"]="/zumba-for-seniors/"
   ["/top-10-fun-activities-for-fitness-in-murwillumbah/"]="/blog/fitness-activities-murwillumbah/"


### PR DESCRIPTION
## Summary
- remove redundant '/' redirect to avoid duplicate path when deploying
- update redirect test script to match new rules

## Testing
- `npm run check`
- `bash test_redirects.sh` *(fails: Could not resolve host)*

------
https://chatgpt.com/codex/tasks/task_e_68c024b15d888325b31a64017633a0d1